### PR TITLE
Add support for remote commands

### DIFF
--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -1,10 +1,11 @@
 name: Build and publish ci container
 
 on:
-  push:
-    branches: ['*']
-    paths:
-      - Dockerfile-ci
+  # Disabled due to rate limiting on http://musl.cc
+  # push:
+  #   branches: ['*']
+  #   paths:
+  #     - Dockerfile-ci
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-image.yaml
+++ b/.github/workflows/ci-image.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-ci:a190170
+  IMAGE_NAME: ${{ github.repository }}-ci
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/${{ github.repository }}-ci:a190170
+      image: ghcr.io/${{ github.repository }}-ci:df116b0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -40,7 +40,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/${{ github.repository }}-ci
+      image: ghcr.io/${{ github.repository }}-ci:df116b0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -65,7 +65,7 @@ jobs:
     name: Build armv7
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/${{ github.repository }}-ci
+      image: ghcr.io/${{ github.repository }}-ci:df116b0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
@@ -94,7 +94,7 @@ jobs:
     name: Build aarch64
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/${{ github.repository }}-ci
+      image: ghcr.io/${{ github.repository }}-ci:df116b0
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,9 +272,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "itoa",
  "matchit",
  "memchr",
@@ -292,8 +302,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -460,12 +470,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -726,6 +737,24 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "delegate"
@@ -1363,7 +1392,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1446,13 +1494,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1484,9 +1566,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1499,17 +1581,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.8",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1772,17 +1890,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -1910,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "olpc-cjson"
 version = "0.1.3"
-source = "git+https://github.com/toradex/tough?branch=rac#9316c096b32196df75ba17a8a5502b19baffe24e"
+source = "git+https://github.com/toradex/tough?branch=rac#69e51d241b950951907b439a9996692967a9e82b"
 dependencies = [
  "serde",
  "serde_json",
@@ -2364,9 +2471,9 @@ dependencies = [
  "env_logger",
  "eyre",
  "futures",
- "http",
+ "http 0.2.12",
  "log",
- "nix 0.26.4",
+ "nix 0.29.0",
  "olpc-cjson 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "portable-pty",
  "pretty_assertions",
@@ -2387,6 +2494,7 @@ dependencies = [
  "url",
  "uuid",
  "vergen",
+ "wiremock",
  "zbus",
 ]
 
@@ -2510,10 +2618,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3081,6 +3189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3549,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "tough"
 version = "0.16.0"
-source = "git+https://github.com/toradex/tough?branch=rac#9316c096b32196df75ba17a8a5502b19baffe24e"
+source = "git+https://github.com/toradex/tough?branch=rac#69e51d241b950951907b439a9996692967a9e82b"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -4155,6 +4269,30 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ portable-pty = "0.8.0"
 socket2 = "0.5.6"
 eyre = "0.6.8"
 futures = { version = "0.3.27", default-features = false, features = ["std", "alloc"] }
-nix = { version = "0.26.2", default-features = false, features = ["user", "fs"] }
+nix = { version = "0.29.0", default-features = false, features = ["user", "fs"] }
 tough = { git = "https://github.com/toradex/tough", branch = "rac", features = ["http", "reqwest"] }
 base64 = "0.21.2"
 serde_json = "1.0.93"
@@ -52,3 +52,4 @@ reqwest = { version = "0.11.13", default-features = false, features = ["blocking
 tokio-retry = "0.3.0"
 ring = { version = "0.17", features = ["std"] }
 olpc-cjson = "0.1.3"
+wiremock = "0.6.3"

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -1,4 +1,5 @@
-FROM rust:1.79-slim-bullseye as builder
+# This needs to be in sync with the rust-toolchain file
+FROM rust:1.75-slim-bullseye as builder
 
 ADD https://musl.cc/aarch64-linux-musl-cross.tgz .
 
@@ -12,7 +13,8 @@ RUN sha256sum arm-linux-musleabihf-cross.tgz | grep -q 11e155a090789c854afb5d91e
     mkdir /opt/arm-linux-musleabihf-cross && \
     tar xvf arm-linux-musleabihf-cross.tgz --strip-component=1 -C /opt/arm-linux-musleabihf-cross
 
-FROM rust:1.79-slim-bullseye
+# This needs to be in sync with the rust-toolchain file
+From rust:1.75-slim-bullseye
 
 RUN apt-get update && apt-get --yes install curl git bash sudo musl-tools openssh-server
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ valid and the public keys are still authorized.
 
 RAC will try to recover from errors and reconnect.
 
+## CI Docker Image
+
+The CI jobs for this app run on Github Actions, which is currently blocked by `musl.cc`. Therefore, we currently do not build the docker image for CI, on CI. If you change the `Dockerfile-ci` file, you will need to manually build and push the new image to docker and update the image reference in the github actions yaml definitions.
+
 ## Usage
 
 Compile with `cargo build --release`, or to cross compile to arm: `cargo build --target aarch64-unknown-linux-musl --release`. You will need the arm musl linker installed. 

--- a/client.toml
+++ b/client.toml
@@ -8,7 +8,7 @@ client_key_path = "device-files/dev/pkey.pem"
 # If this file does not exist, a new key will be generated and saved to this file
 ssh_private_key_path = "./device-key-01.sec"
 # unprivileged_user_group = "simao:simao"
-poll_timeout = { secs = 60, nanos = 0 }
+poll_timeout = { secs = 4, nanos = 0 }
 validation_poll_timeout = { secs = 60, nanos = 0 }
 
 # [device.session.target_host]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+# The toolchain version cannot be changed without agreement from the torizon os team
+[toolchain]
+channel = "1.75"
+components = [ "rustfmt", "clippy", "rust-analyzer" ]
+targets = ["x86_64-unknown-linux-musl", "armv7-unknown-linux-musleabihf", "aarch64-unknown-linux-musl"]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,311 @@
+// Copyright 2025 Toradex A.G.
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::module_name_repetitions)]
+
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chrono::Local;
+use eyre::Context;
+use eyre::OptionExt;
+use log::debug;
+use log::error;
+use log::warn;
+use nix::fcntl::Flock;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::data_type::*;
+
+use crate::Result;
+
+// The goal of persisting command results to disk is to cover the
+// following failure modes:
+//
+// 1. The Command execution starts, and then RAC is killed or
+// crashes. On the next RAC run, rac picks up the command from disk
+// and reports a failure to the server, before polling for new
+// commands.
+//
+// 2. The Command execution starts and finishes, but RAC cannot send
+// the result back to the server. On the next command polling run, RAC
+// will try to send the output back to the server, before polling for
+// new commands.
+//
+// 3. A concurrent execution of RAC will try to run the same Command
+// at the same time. RAC will write and lock a file to disk and try to
+// prevent a double execution of the command.
+//
+// Every other failure mode related with the execution and persistence
+// of command results to disk is undefined behavior.
+#[derive(Debug)]
+pub struct CommandStore {
+    base_dir: PathBuf,
+    locks: HashMap<CommandId, nix::fcntl::Flock<std::fs::File>>,
+}
+
+impl CommandStore {
+    #[must_use]
+    pub fn new(base_dir: PathBuf) -> CommandStore {
+        Self {
+            base_dir,
+            locks: HashMap::new(),
+        }
+    }
+
+    fn file_path(&self, cmd_id: &CommandId) -> PathBuf {
+        format!("{}/{cmd_id}.cmd", self.base_dir.display()).into()
+    }
+
+    async fn set_file_lock<'a>(
+        &'a mut self,
+        cmd_id: &CommandId,
+    ) -> Result<&'a mut Flock<std::fs::File>> {
+        if !self.locks.contains_key(cmd_id) {
+            tokio::fs::create_dir_all(&self.base_dir)
+                .await
+                .context(format!("create_dir_all {}", self.base_dir.display()))?;
+
+            let file_path = self.file_path(cmd_id);
+
+            let file = tokio::task::spawn_blocking(move || {
+                let file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(false)
+                    .open(&file_path)
+                    .context(format!("file_path {}", file_path.display()))?;
+
+                let file = match nix::fcntl::Flock::lock(
+                    file,
+                    nix::fcntl::FlockArg::LockExclusiveNonblock,
+                ) {
+                    Ok(l) => l,
+                    Err((_, err)) => return Err(err.into()),
+                };
+
+                Ok::<Flock<std::fs::File>, eyre::Report>(file)
+            })
+            .await??;
+
+            self.locks.insert(*cmd_id, file);
+        }
+
+        #[allow(clippy::unwrap_used)] // initialized if didn't exist
+        let file_lock = self.locks.get_mut(cmd_id).unwrap();
+
+        Ok(file_lock)
+    }
+
+    async fn unset_file_lock(&mut self, cmd_id: &CommandId, keep_file_result: bool) -> Result<()> {
+        let _file = self.locks.remove(cmd_id).ok_or_eyre("lock was not set")?;
+
+        if !keep_file_result {
+            tokio::fs::remove_file(self.file_path(cmd_id)).await?;
+        }
+
+        Ok(()) // _file is dropped here, closing the file and releasing the lock
+    }
+
+    pub async fn start(&mut self, cmd_id: &CommandId) -> Result<()> {
+        self.set_file_lock(cmd_id).await?;
+        Ok(())
+    }
+
+    pub async fn result_pending(
+        &mut self,
+        cmd_id: &CommandId,
+        result: CommandResult,
+        error: eyre::Report,
+    ) -> Result<()> {
+        let file = self.set_file_lock(cmd_id).await?;
+
+        let payload = RunData {
+            cmd_id: *cmd_id,
+            output: result,
+            error: Some(format!("{error}").to_owned()),
+        };
+
+        let json = serde_json::to_string_pretty(&payload)?;
+
+        // blocking IO
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        file.write_all(&json.into_bytes())?;
+        file.sync_all()?;
+
+        self.unset_file_lock(cmd_id, true).await?;
+
+        Ok(())
+    }
+
+    pub async fn find_pending(&mut self) -> Result<Vec<(CommandId, CommandResult)>> {
+        let mut pending = Vec::new();
+
+        if !tokio::fs::try_exists(&self.base_dir).await? || !self.base_dir.is_dir() {
+            return Ok(pending);
+        }
+
+        let mut entries = tokio::fs::read_dir(&self.base_dir).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+
+            if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("cmd") {
+                debug!("unexpected file {path:?}");
+                continue;
+            }
+
+            let Ok(content) = tokio::fs::read_to_string(&path).await else {
+                debug!("could read {path:?}");
+                continue;
+            };
+
+            let run_data = match serde_json::from_str::<RunData>(&content) {
+                Ok(run_data) => run_data,
+                Err(err) => {
+                    warn!("could not parse contents of {path:?}: {err:?} try to finish command");
+
+                    let cmd_id: Result<CommandId> = path
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .map(|f| f.trim_end_matches(".cmd").to_owned())
+                        .ok_or_eyre("invalid cmd output filename")
+                        .and_then(String::try_into);
+
+                    if let Err(err) = cmd_id {
+                        error!("could not end command {err:?}");
+                        continue;
+                    }
+
+                    RunData {
+                        cmd_id: cmd_id?,
+                        output: CommandResult {
+                            success: false,
+                            stdout: "unknown".into(),
+                            stderr: "unknown".into(),
+                            error: Some(
+                                "a lock file for the command exists, but no output is available"
+                                    .into(),
+                            ),
+                            exit_code: None,
+                            finished_at: chrono::Utc::now(),
+                        },
+                        error: Some(
+                            "a lock file for the command exists, but no output is available".into(),
+                        ),
+                    }
+                }
+            };
+
+            if self.locks.contains_key(&run_data.cmd_id) {
+                debug!(
+                    "there is an existent lock for {}, not reporting this cmd",
+                    &run_data.cmd_id
+                );
+                continue;
+            }
+
+            pending.push((run_data.cmd_id, run_data.output));
+
+            // limit to 10 per call so that a single client is not
+            // stuck on sending too many results at the same time
+            if pending.len() >= 10 {
+                break;
+            }
+        }
+
+        Ok(pending)
+    }
+
+    pub async fn result_sent(&mut self, cmd_id: &CommandId) -> Result<()> {
+        self.set_file_lock(cmd_id).await?;
+        self.unset_file_lock(cmd_id, false).await?;
+        Ok(())
+    }
+
+    pub async fn is_pending(&mut self, cmd_id: &CommandId) -> Result<bool> {
+        if self.find_pending().await?.iter().any(|p| p.0 == *cmd_id) {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct RunData {
+    cmd_id: CommandId,
+    output: CommandResult,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
+pub struct EchoAction;
+
+impl EchoAction {
+    pub async fn execute(self, args: &[String]) -> crate::Result<std::process::Output> {
+        use tokio::process::Command;
+
+        let mut output = Command::new("echo").args(args).output().await?;
+
+        let str_output = String::from_utf8_lossy(&output.stdout).to_string();
+
+        output.stdout = str_output
+            .trim_end_matches(|c: char| c.is_whitespace())
+            .into();
+
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
+pub struct RebootAction;
+
+impl RebootAction {
+    pub async fn execute(self) -> crate::Result<std::process::Output> {
+        // Implement reboot action logic here
+        use tokio::process::Command;
+
+        let reboot_when = Local::now() + Duration::from_secs(30);
+        let when_str = format!("--when={}", reboot_when.format("%Y-%m-%d %H:%M:%S"));
+
+        // requires sudo
+        let output = Command::new("sudo")
+            .arg("systemctl")
+            .arg("reboot")
+            .arg(&when_str)
+            .output()
+            .await?;
+
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
+pub struct RebootServiceAction {}
+
+impl RebootServiceAction {
+    pub async fn execute(self, args: &[String]) -> crate::Result<std::process::Output> {
+        use tokio::process::Command;
+
+        let name = args
+            .first()
+            .ok_or_eyre("restart: no argument for service name")?;
+
+        // requires sudo
+        let output = Command::new("sudo")
+            .arg("systemctl")
+            .arg("restart")
+            .arg(name)
+            .output()
+            .await?;
+
+        Ok(output)
+    }
+}

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -2,7 +2,7 @@ use serde;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "command", content = "args")]
 pub enum Event {
     PollRasNow(serde_json::Value),

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -1,0 +1,726 @@
+#![allow(clippy::module_name_repetitions)]
+
+use crate::data_type::{Command, DeviceSession};
+use crate::dbus::Event;
+use crate::{command::*, CommandResult, UptaneMetadataProvider, ValidCommand};
+use crate::{data_type::RacConfig, dbus};
+use chrono::Utc;
+use eyre::Context;
+use futures::stream::StreamExt;
+use futures::FutureExt;
+use futures::{future, Stream};
+use log::*;
+use serde_json::json;
+use tokio::sync::broadcast::{Receiver, Sender};
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::TorizonClient;
+
+async fn start_poll_loop<T>(rac_cfg: RacConfig, mut dbus_events: Receiver<Event>, mut ras: T)
+where
+    T: RasPoll,
+{
+    // Needs to poll before timer fires
+    ras.poll(&rac_cfg, &mut dbus_events).await;
+
+    let poll_timer = tokio::time::sleep(rac_cfg.device.poll_timeout);
+    tokio::pin!(poll_timer);
+
+    loop {
+        debug!("{}: waiting for poll events", std::any::type_name::<T>());
+
+        tokio::select! {
+            () = &mut poll_timer =>
+                ras.poll(&rac_cfg, &mut dbus_events).await,
+            event = dbus_events.recv() => {
+                match event {
+                    Ok(Event::PollRasNow(_)) =>
+                        ras.poll(&rac_cfg, &mut dbus_events).await,
+                    Err(err) =>
+                        warn!("{}: could not poll and execute: {err:?}", std::any::type_name::<T>()),
+                }
+            },
+        }
+
+        poll_timer
+            .as_mut()
+            .reset(tokio::time::Instant::now() + rac_cfg.device.poll_timeout);
+    }
+}
+
+trait RasPoll: std::fmt::Debug {
+    async fn poll(&mut self, rac_cfg: &RacConfig, dbus_events: &mut Receiver<dbus::Event>);
+}
+
+#[derive(Debug)]
+struct CommandPolling<V: UptaneMetadataProvider = TorizonClient> {
+    ras_client: TorizonClient,
+    metadata_provider: V,
+    cmd_store: CommandStore,
+}
+
+impl<V: UptaneMetadataProvider> CommandPolling<V> {
+    async fn poll_for_new_commands(
+        ras_client: &TorizonClient,
+        metadata_provider: &V,
+    ) -> Result<Option<Command>, eyre::Report> {
+        let mut commands = ras_client
+            .get_commands()
+            .await
+            .wrap_err("Could not get session data from server")?
+            .values;
+
+        debug!("commands received: {commands:?}");
+
+        let min_key = commands.keys().min().copied();
+
+        // Only return the lowest priority command
+        let cmd_opt = min_key.and_then(|k| commands.remove(&k));
+
+        // validate RAS command against uptane metadata
+        if let Some(cmd) = cmd_opt {
+            let cmd_valid = crate::valid_command_metadata(metadata_provider, &cmd).await?;
+            #[allow(clippy::if_not_else)]
+            if cmd_valid != ValidCommand::Valid {
+                debug!("command from server is invalid: {:#?}", &cmd);
+                error!("invalid command received from server: {:#?}", &cmd_valid);
+
+                let error = json!({
+                    "message": "invalid command received from server",
+                    "validation_result": &cmd_valid
+                });
+
+                let result = CommandResult {
+                    success: false,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    error: Some(error),
+                    exit_code: None,
+                    finished_at: chrono::Utc::now(),
+                };
+
+                ras_client.send_command_result(&cmd.id, &result).await?;
+
+                Ok(None)
+            } else {
+                Ok(Some(cmd))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<V: UptaneMetadataProvider> RasPoll for CommandPolling<V> {
+    async fn poll(&mut self, rac_cfg: &RacConfig, _dbus: &mut Receiver<Event>) {
+        async fn execute<V: UptaneMetadataProvider>(
+            ras_client: &TorizonClient,
+            rac_cfg: &RacConfig,
+            metadata_provider: &V,
+            cmd_store: &mut CommandStore,
+        ) -> Result<(), eyre::Report> {
+            for (cmd_id, res) in cmd_store.find_pending().await? {
+                cmd_store.start(&cmd_id).await?;
+
+                if let Err(err) = ras_client.send_command_result(&cmd_id, &res).await {
+                    warn!("could not send pending command result: {err:?}");
+                    cmd_store.result_pending(&cmd_id, res, err).await?;
+                } else {
+                    debug!("finished pending cmd {}", &cmd_id);
+                    cmd_store.result_sent(&cmd_id).await?;
+                }
+            }
+
+            if let Some(cmd) =
+                CommandPolling::<V>::poll_for_new_commands(ras_client, metadata_provider).await?
+            {
+                info!("running command {:?}", &cmd);
+
+                if cmd_store.is_pending(&cmd.id).await? {
+                    warn!(
+                        "command {:?} returned from server still pending, not executing again",
+                        &cmd.id
+                    );
+                    return Ok(());
+                }
+
+                cmd_store.start(&cmd.id).await?;
+
+                match crate::run_command(rac_cfg, &cmd).await {
+                    Ok(result) => {
+                        if let Err(err) = ras_client.send_command_result(&cmd.id, &result).await {
+                            warn!("could not send command result: {err:?}");
+                            cmd_store.result_pending(&cmd.id, result, err).await?;
+                        } else {
+                            debug!("command result sent");
+
+                            cmd_store.result_sent(&cmd.id).await?;
+                        }
+
+                        info!("command finished");
+                    }
+                    Err(err) => {
+                        cmd_store.result_sent(&cmd.id).await?;
+                        error!("could not run command: {err:?}");
+                    }
+                }
+            } else {
+                info!("no new commands in RAS");
+            };
+
+            Ok(())
+        }
+        if let Err(err) = execute::<V>(
+            &self.ras_client,
+            rac_cfg,
+            &self.metadata_provider,
+            &mut self.cmd_store,
+        )
+        .await
+        {
+            error!("error, trying later {err:?}");
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SshPolling {
+    ras_client: TorizonClient,
+    rac_cfg: RacConfig,
+}
+
+impl SshPolling {
+    async fn poll_for_new_sessions(&self) -> Result<Option<DeviceSession>, eyre::Report> {
+        let session = self
+            .ras_client
+            .get_session()
+            .await
+            .wrap_err("Could not get session data from server")?;
+
+        let session = match session {
+            None => {
+                debug!("No sessions available for this device");
+                return Ok(None);
+            }
+            Some(s) => s,
+        };
+
+        debug!("{session:?}");
+        info!("Received new session");
+
+        if Utc::now() > session.ssh.expires_at {
+            warn!("session expired at {}", session.ssh.expires_at);
+        }
+
+        Ok(Some(session))
+    }
+}
+
+impl RasPoll for SshPolling {
+    async fn poll(&mut self, _rac_cfg: &RacConfig, dbus_events: &mut Receiver<Event>) {
+        match self.poll_for_new_sessions().await {
+            Ok(Some(session)) => {
+                if let Err(err) =
+                    crate::keep_session_loop(&self.rac_cfg, &self.ras_client, &session, dbus_events)
+                        .await
+                {
+                    error!("error in ssh session loop: {:?}", err);
+                } else {
+                    info!("ssh session closed");
+                }
+            }
+            Ok(None) => info!("no sessions available in RAS"),
+            Err(err) => error!("could not get sessions, trying later {err:?}"),
+        }
+    }
+}
+
+pub async fn start_remote_commands_event_loop(
+    ras_client: TorizonClient,
+    rac_cfg: RacConfig,
+    dbus_events: Receiver<Event>,
+) {
+    let persist = CommandStore::new(rac_cfg.device.commands_dir.clone());
+
+    let poll = CommandPolling {
+        ras_client: ras_client.clone(),
+        cmd_store: persist,
+        metadata_provider: ras_client,
+    };
+
+    start_poll_loop(rac_cfg, dbus_events, poll).await;
+}
+
+pub async fn start_ssh_event_loop(
+    dbus_events: Receiver<Event>,
+    rac_cfg: RacConfig,
+    ras_client: TorizonClient,
+) {
+    let poll = SshPolling {
+        ras_client,
+        rac_cfg: rac_cfg.clone(),
+    };
+
+    start_poll_loop(rac_cfg, dbus_events, poll).await;
+}
+
+fn start_dbus_channel(rac_cfg: &RacConfig) -> Box<dyn Stream<Item = dbus::Event> + Send + Unpin> {
+    if rac_cfg.device.enable_dbus_client {
+        let rx = dbus::client::start();
+        info!("subscribed to dbus signals");
+        Box::new(ReceiverStream::new(rx))
+    } else {
+        info!("dbus client disabled");
+        Box::new(future::pending().into_stream())
+    }
+}
+
+pub async fn start_dbus_loop(rac_cfg: RacConfig, cmd_tx: Sender<Event>) {
+    loop {
+        let mut dbus_events = start_dbus_channel(&rac_cfg);
+
+        loop {
+            debug!("waiting for new sessions for this device");
+
+            if let Some(event) = dbus_events.next().await {
+                if let Err(err) = cmd_tx.send(event) {
+                    warn!("could not broadcast dbus event: {err:?}");
+                }
+            } else {
+                warn!("dbus stream closed");
+                break;
+            }
+        }
+
+        info!(
+            "waiting for {:?} before retrying to reconnect to dbus",
+            rac_cfg.device.poll_timeout
+        );
+        tokio::time::sleep(rac_cfg.device.poll_timeout).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_type::{CommandId, CommandResult, CommandsResponse};
+    use serde_json::json;
+    use std::collections::HashMap;
+    use tempfile::tempdir;
+    use tough::schema::RemoteSessions;
+    use url::Url;
+    use wiremock::{
+        matchers::{body_json_schema, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    struct TestContext {
+        polling: CommandPolling<MockUptaneProvider>,
+        mock_server: MockServer,
+        dbus_events: Receiver<Event>,
+        rac_cfg: RacConfig,
+    }
+
+    pub struct CommandResultMatcher(CommandResult);
+
+    impl wiremock::Match for CommandResultMatcher {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            let mut req_body: CommandResult = match request.body_json() {
+                Ok(b) => b,
+                Err(err) => {
+                    debug!("command result body did not match: {err:?}");
+                    return false;
+                }
+            };
+
+            // Set the finished_at time to match the expected result for comparison
+            req_body.finished_at = self.0.finished_at;
+
+            // compare only the error message
+            let error = req_body.error.and_then(|error_json| {
+                error_json
+                    .get("message")
+                    .and_then(|msg| msg.as_str().map(str::to_owned))
+            });
+
+            let expected_error = self.0.error.as_ref().and_then(|error_json| {
+                error_json
+                    .get("message")
+                    .and_then(|msg| msg.as_str().map(str::to_owned))
+            });
+
+            if error != expected_error {
+                return false;
+            }
+
+            req_body.error = self.0.error.clone();
+
+            req_body == self.0
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockUptaneProvider;
+
+    impl UptaneMetadataProvider for MockUptaneProvider {
+        async fn fetch_verified_remote_sessions(&self) -> crate::Result<RemoteSessions> {
+            Ok(RemoteSessions {
+                remote_sessions: json!({}),
+                remote_commands: Some(json!({
+                    "allowed_commands": {
+                        "restart-service": {
+                            "args": [
+                                "aktualizr"
+                            ]
+                        },
+                        "echo": {
+                            "args": ["test"]
+                        }
+                    },
+                    "version": "v1alpha"
+                })),
+                expires: chrono::Utc::now() + std::time::Duration::from_secs(3600),
+                #[allow(clippy::unwrap_used)]
+                version: std::num::NonZeroU64::new(1).unwrap(),
+                _extra: HashMap::new(),
+            })
+        }
+    }
+
+    impl TestContext {
+        async fn new() -> Self {
+            let temp_dir = tempdir().expect("Failed to create temp directory");
+            let temp_path = temp_dir.path().to_path_buf();
+            let cmd_store = CommandStore::new(temp_path);
+
+            let mock_server = MockServer::start().await;
+            let base_url = Url::parse(&mock_server.uri()).expect("Failed to parse URL");
+
+            let rac_config = RacConfig {
+                torizon: crate::data_type::TorizonConfig {
+                    url: base_url.clone(),
+                    director_url: Some(base_url),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let http_client = reqwest::Client::builder()
+                .build()
+                .expect("Failed to build HTTP client");
+            let ras_client = TorizonClient::new(rac_config.clone(), http_client);
+
+            // 10 = max number of dbus messages in a single burst this
+            // client can handle
+            let (_tx, dbus_events) = tokio::sync::broadcast::channel(10);
+
+            Self {
+                polling: CommandPolling::<MockUptaneProvider> {
+                    ras_client,
+                    cmd_store,
+                    metadata_provider: MockUptaneProvider {},
+                },
+                mock_server,
+                dbus_events,
+                rac_cfg: rac_config,
+            }
+        }
+
+        fn create_command(&self) -> (CommandId, Command) {
+            let cmd_id = CommandId::generate();
+            let command = Command {
+                id: cmd_id,
+                name: crate::data_type::CommandName::Echo(EchoAction),
+                args: vec!["test".to_string()],
+                created_at: chrono::Utc::now(),
+            };
+            (cmd_id, command)
+        }
+
+        async fn mock_get_commands(&self, commands: HashMap<u32, Command>) {
+            let response = CommandsResponse { values: commands };
+
+            Mock::given(method("GET"))
+                .and(path("/commands"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+                .expect(1)
+                .mount(&self.mock_server)
+                .await;
+        }
+
+        async fn mock_post_command_result(
+            &self,
+            cmd_id: &CommandId,
+            status: u16,
+            result: Option<CommandResult>,
+        ) {
+            let path_str = format!("/commands/{cmd_id}/result");
+
+            let mut mock = Mock::given(method("POST"))
+                .and(path(path_str))
+                .and(body_json_schema::<CommandResult>);
+
+            let name =
+                format!("command result status={status} cmd_id={cmd_id:?} result={result:?}");
+
+            if let Some(res) = result {
+                mock = mock.and(CommandResultMatcher(res));
+            }
+
+            mock.respond_with(ResponseTemplate::new(status).set_body_json(json!({})))
+                .expect(1)
+                .named(name)
+                .mount(&self.mock_server)
+                .await;
+        }
+
+        async fn mock_reset(&self) {
+            self.mock_server.verify().await;
+            self.mock_server.reset().await;
+        }
+
+        async fn create_pending_result(&mut self, cmd_id: &CommandId) -> CommandResult {
+            let result = CommandResult {
+                success: true,
+                stdout: "test output".to_string(),
+                stderr: String::new(),
+                exit_code: Some(0),
+                error: None,
+                finished_at: chrono::Utc::now(),
+            };
+
+            self.polling
+                .cmd_store
+                .start(cmd_id)
+                .await
+                .expect("Failed to start command");
+
+            self.polling
+                .cmd_store
+                .result_pending(cmd_id, result.clone(), eyre::eyre!("Pending test error"))
+                .await
+                .expect("Failed to set pending result");
+
+            result
+        }
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_success() {
+        let mut ctx = TestContext::new().await;
+        let (cmd_id, command) = ctx.create_command();
+
+        let expect = CommandResult {
+            success: true,
+            stdout: command.args.join(""),
+            stderr: String::new(),
+            exit_code: Some(0),
+            error: None,
+            finished_at: chrono::Utc::now(),
+        };
+
+        ctx.mock_get_commands(HashMap::from([(0, command)])).await;
+
+        ctx.mock_post_command_result(&cmd_id, 200, Some(expect))
+            .await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert!(pending_commands.is_empty(), "Expected no pending commands");
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_invalid_uptane_metadata() {
+        let mut ctx = TestContext::new().await;
+
+        let cmd_id = CommandId::generate();
+        let command = Command {
+            id: cmd_id,
+            name: crate::data_type::CommandName::Reboot(RebootAction),
+            args: Vec::new(),
+            created_at: chrono::Utc::now(),
+        };
+
+        let expect = CommandResult {
+            success: false,
+            stdout: String::new(),
+            stderr: String::new(),
+            error: Some(json!({"message": "invalid command received from server"})), // rest of body will not be matched
+            exit_code: None,
+            finished_at: chrono::Utc::now(),
+        };
+
+        ctx.mock_get_commands(HashMap::from([(0, command)])).await;
+
+        ctx.mock_post_command_result(&cmd_id, 200, Some(expect))
+            .await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert!(pending_commands.is_empty(), "Expected no pending commands");
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_no_commands() {
+        let mut ctx = TestContext::new().await;
+
+        ctx.mock_get_commands(HashMap::new()).await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert!(pending_commands.is_empty(), "Expected no pending commands");
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_send_pending_results() {
+        let mut ctx = TestContext::new().await;
+        let (cmd_id, _) = ctx.create_command();
+
+        let result = ctx.create_pending_result(&cmd_id).await;
+
+        ctx.mock_get_commands(HashMap::new()).await;
+
+        ctx.mock_post_command_result(&cmd_id, 200, Some(result))
+            .await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+
+        assert!(pending_commands.is_empty(), "Expected no pending commands");
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_failed_to_send_result() {
+        let mut ctx = TestContext::new().await;
+        let (cmd_id, command) = ctx.create_command();
+
+        ctx.mock_get_commands(HashMap::from([(0, command)])).await;
+
+        ctx.mock_post_command_result(&cmd_id, 500, None).await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert_eq!(pending_commands.len(), 1, "Expected one pending command");
+        assert_eq!(
+            pending_commands[0].0, cmd_id,
+            "Expected pending command to match created command"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_retry_after_server_down() {
+        let mut ctx = TestContext::new().await;
+        let (cmd_id, command) = ctx.create_command();
+
+        ctx.mock_get_commands(HashMap::from([(0, command)])).await;
+
+        ctx.mock_post_command_result(&cmd_id, 500, None).await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert_eq!(pending_commands.len(), 1, "Expected one pending command");
+        assert_eq!(
+            pending_commands[0].0, cmd_id,
+            "Expected pending command to match created command"
+        );
+
+        ctx.mock_reset().await;
+
+        ctx.mock_get_commands(HashMap::new()).await;
+
+        let result = pending_commands[0].1.clone();
+        ctx.mock_post_command_result(&cmd_id, 200, Some(result.clone()))
+            .await;
+
+        // Second poll - should retry sending the pending result
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert!(
+            pending_commands.is_empty(),
+            "Expected no pending commands after successful retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_poll_and_run_command_not_executed_when_pending_result_exists() {
+        let mut ctx = TestContext::new().await;
+        let (cmd_id, command) = ctx.create_command();
+
+        ctx.mock_get_commands(HashMap::from([(0, command.clone())]))
+            .await;
+        ctx.mock_post_command_result(&cmd_id, 500, None).await;
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert_eq!(pending_commands.len(), 1, "Expected one pending command");
+        let pending_result = pending_commands[0].1.clone();
+
+        ctx.mock_reset().await;
+
+        // Second poll - server returns the same command again
+        // But we should only try to send the pending result, not execute the command again
+        ctx.mock_get_commands(HashMap::from([(0, command)])).await;
+
+        // should only be called once, for pending result, not for a new execution
+        ctx.mock_post_command_result(&cmd_id, 500, Some(pending_result))
+            .await;
+
+        ctx.polling.poll(&ctx.rac_cfg, &mut ctx.dbus_events).await;
+
+        // Verify there are no more pending commands
+        let pending_commands = ctx
+            .polling
+            .cmd_store
+            .find_pending()
+            .await
+            .expect("Failed to find pending commands");
+        assert!(!pending_commands.is_empty(), "Expected pending commands");
+    }
+}

--- a/src/local_session.rs
+++ b/src/local_session.rs
@@ -179,7 +179,7 @@ impl SessionLifecycle for SpawnedSshdSession {
 
         self.used_port = Some(port);
 
-        let f = handle.map(|status| Ok(warn!("spawned_sshd exited with {status:?}")));
+        let f = handle.map(|status| Ok(() = warn!("spawned_sshd exited with {status:?}")));
 
         return Ok(f.boxed());
     }


### PR DESCRIPTION
Run multiple poll loops. One for remote commands, another for remote sessions. Currently with the same polling interval configuration.

An MQTT poll notification will poll for both sessions and commands.

Added two configuration options:

- `device.commands_dir` - This needs to point to a writable directory. RAC will keep state about running commands in this directory so it can properly notify the server about the state of execution.

- `device.commands_timeout` - The default timeout for running commands. If the command do not finish in this interval, it will be interrupted and a failure will be reported.

Currently the following commands are supported:

- reboot - The command `sudo systemctl reboot` will be executed. The reboot will be scheduled for 30 seconds later, and the successful scheduling of the command will cause the command to be considered successfully executed and that status will be reported back to RAS.

- restart-service - The service given in argument will be restarted via `sudo systemctl restart <service>`.

Notice that both commands will use sudo, since RAC is assumed to be running with an unprivileged user. The sudoers file needs to be appropriately provisioned for this execution to be successful.

Both the arguments and the commands will be verified against the metadata available in an uptane validated `remote-sessions.json` metadata.

See the `commands.rs` file for the failure modes covered by this implementation when running remote commands.